### PR TITLE
 Cria opção de pesquisa no Querido Diário

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -22,7 +22,7 @@ jobs:
       run: cd Ro-dou && make install-deps
 
     - name: Run docker-compose
-      run: cd Ro-dou && make up
+      run: cd Ro-dou && make run
 
     - name: run tests
       run: cd Ro-dou && make tests

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 install-deps:
 	git clone https://github.com/economiagovbr/FastETL.git
 
-.PHONY: up
-up: setup-containers create-example-variable
+.PHONY: run
+run: setup-containers create-example-variable
 
 setup-containers:
 	docker-compose up -d --force-recreate --remove-orphans

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 O Ro-dou é uma ferramenta para gerar dinamicamente DAGs no
 [Apache Airflow](https://airflow.apache.org/) que fazem *clipping* do Diário
-Oficial da União ([DOU](https://www.gov.br/imprensanacional/pt-br)) e do Querido Diário ([QD](https://queridodiario.ok.org.br/)). Receba no email todas as publicações que contenham as
+Oficial da União ([DOU](https://www.gov.br/imprensanacional/pt-br)) e dos Diários Oficiais de municípios por meio do Querido Diário ([QD](https://queridodiario.ok.org.br/)). Receba no email todas as publicações que contenham as
 **palavras chaves** que você definir.
 
 Veja uma apresentação completa no canal da ENAP no [YouTube](https://www.youtube.com/watch?v=phCa8GJOHY0),

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 O Ro-dou é uma ferramenta para gerar dinamicamente DAGs no
 [Apache Airflow](https://airflow.apache.org/) que fazem *clipping* do Diário
-Oficial da União ([DOU](https://www.gov.br/imprensanacional/pt-br)) a partir de
-arquivos **YAML**. Receba no email todas as publicações que contenham as
+Oficial da União ([DOU](https://www.gov.br/imprensanacional/pt-br)) e do Querido Diário ([QD](https://queridodiario.ok.org.br/)). Receba no email todas as publicações que contenham as
 **palavras chaves** que você definir.
 
 Veja uma apresentação completa no canal da ENAP no [YouTube](https://www.youtube.com/watch?v=phCa8GJOHY0),
@@ -211,7 +210,32 @@ dag:
       - email-destino@economia.gov.br
 ```
 
-## Compreendendo um pouco mais a engenhoca
+### Exemplo 6
+Esta configuração produz uma DAG que pesquisa no Querido Diário pelos termos
+pandemia, dados pessoais e prefeitura buscando apenas os resultados do Diário
+Oficial de Belo Horizonte. Para conhecer o Querido Diário acesse
+[https://queridodiario.ok.org.br/](https://queridodiario.ok.org.br/).
+
+```yaml {5,6,7}
+dag:
+  id: dou_qd_example
+  description: DAG de teste
+  search:
+    sources:
+    - QD
+    territory_id: 3106200 # Belo Horizonte
+    terms:
+    - pandemia
+    - dados pessoais
+    - prefeitura
+  report:
+    emails:
+      - destination@economia.gov.br
+    attach_csv: True
+    subject: "Teste do Ro-dou"
+```
+
+## Compreendendo um pouco mais a pesquisa no DOU
 
 Todos os parâmetros disponíveis para pesquisa foram criados a partir da API da
 Imprensa Nacional que por sua vez é utilizada pelo buscador oficial do DOU em

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ make install-deps
 Este comando baixa as dependências necessárias.
 
 ```bash
-make up
+make run
 ```
 Este comando baixa as imagens docker e sobe todos os contêineres do Ro-dou.
 
@@ -88,7 +88,7 @@ serviço **smtp4dev** uma vez que ele não será mais necessário.
 É isso! Agora basta subir o Ro-dou executando o comando:
 
 ```bash
-make up
+make run
 ```
 
 # Exemplos de Configuração YAML

--- a/dag_confs/dou_qd_example.yaml
+++ b/dag_confs/dou_qd_example.yaml
@@ -1,0 +1,17 @@
+dag:
+  id: dou_qd_example
+  description: DAG de teste
+  search:
+    sources:
+    - QD
+    territory_id: 3106200
+    terms:
+    - pandemia
+    - dados pessoais
+    - prefeitura
+  report:
+    emails:
+      - destination@economia.gov.br
+    attach_csv: True
+    subject: "Teste do Ro-dou"
+

--- a/src/dou_dag_generator.py
+++ b/src/dou_dag_generator.py
@@ -29,7 +29,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
 from parsers import YAMLParser
-from searchers import DOUSearcher
+from searchers import BaseSearcher, DOUSearcher, QDSearcher
 
 class DouDigestDagGenerator():
     """
@@ -43,10 +43,11 @@ class DouDigestDagGenerator():
     YAMLS_DIR = os.path.join(SOURCE_DIR, 'dag_confs/')
 
     parser = YAMLParser
-    searcher = DOUSearcher
+    searcher = BaseSearcher
 
     def __init__(self, on_retry_callback=None, on_failure_callback=None):
-        self.searcher = DOUSearcher()
+        self.searcher = QDSearcher()
+        # self.searcher = DOUSearcher()
         self.on_retry_callback = on_retry_callback
         self.on_failure_callback = on_failure_callback
 

--- a/src/dou_dag_generator.py
+++ b/src/dou_dag_generator.py
@@ -120,7 +120,7 @@ class DouDigestDagGenerator():
 
             exec_dou_search_task = PythonOperator(
                 task_id='exec_dou_search',
-                python_callable=self.searcher.exec_dou_search,
+                python_callable=self.searcher.exec_search,
                 op_kwargs={
                     'term_list': term_list,
                     'dou_sections': dou_sections,

--- a/src/dou_dag_generator.py
+++ b/src/dou_dag_generator.py
@@ -75,6 +75,7 @@ class DouDigestDagGenerator():
     def create_dag(self,
                    dag_id,
                    sources,
+                   territory_id,
                    dou_sections,
                    search_date,
                    search_field,
@@ -130,6 +131,7 @@ class DouDigestDagGenerator():
                 python_callable=self.perform_searchs,
                 op_kwargs={
                     'sources': sources,
+                    'territory_id': territory_id,
                     'term_list': term_list,
                     'dou_sections': dou_sections,
                     'search_date': search_date,
@@ -172,6 +174,7 @@ class DouDigestDagGenerator():
     def perform_searchs(
         self,
         sources,
+        territory_id,
         term_list,
         dou_sections: [str],
         search_date,
@@ -195,6 +198,7 @@ class DouDigestDagGenerator():
 
         if 'QD' in sources:
             qd_result = self.searchers['QD'].exec_search(
+                territory_id,
                 term_list,
                 dou_sections,
                 search_date,

--- a/src/dou_dag_generator.py
+++ b/src/dou_dag_generator.py
@@ -13,6 +13,8 @@ import os
 import ast
 from tempfile import NamedTemporaryFile
 import textwrap
+from typing import Dict, List
+
 import markdown
 import pandas as pd
 
@@ -279,6 +281,27 @@ class DouDigestDagGenerator():
                 match['abstract'],
                 match['date'],
                 )
+
+
+def _merge_dict(dict1, dict2):
+    """Merge dictionaries and sum values of common keys"""
+    dict3 = {**dict1, **dict2}
+    for key, value in dict3.items():
+        if key in dict1 and key in dict2:
+                dict3[key] = value + dict1[key]
+    return dict3
+
+
+SearchResult = Dict[str, Dict[str, List[dict]]]
+
+def merge_results(result_1: SearchResult,
+                  result_2: SearchResult) -> SearchResult:
+    """Merge search results by group and term as keys"""
+    return {
+        group: _merge_dict(result_1.get(group, {}),
+                           result_2.get(group, {}))
+        for group in set((*result_1, *result_2))}
+
 
 # Run dag generation
 DouDigestDagGenerator().generate_dags()

--- a/src/dou_dag_generator.py
+++ b/src/dou_dag_generator.py
@@ -174,7 +174,7 @@ class DouDigestDagGenerator():
         return dag
 
 
-    def perform_searchs(
+    def perform_searches(
         self,
         sources,
         territory_id,

--- a/src/dou_dag_generator.py
+++ b/src/dou_dag_generator.py
@@ -14,7 +14,7 @@ import ast
 from tempfile import NamedTemporaryFile
 import textwrap
 from typing import Dict, List
-
+import logging
 import markdown
 import pandas as pd
 
@@ -188,6 +188,7 @@ class DouDigestDagGenerator():
         **context) -> dict:
         """Performs the search in each source and merge the results
         """
+        logging.info('Searching for the following terms: %s', ','.join(term_list))
         if 'DOU' in sources:
             dou_result = self.searchers['DOU'].exec_search(
                 term_list,

--- a/src/dou_dag_generator.py
+++ b/src/dou_dag_generator.py
@@ -111,6 +111,9 @@ class DouDigestDagGenerator():
             schedule_interval=schedule,
             description=description,
             catchup=False,
+            params={
+                "trigger_date": "2022-01-02T12:00"
+            },
             tags=tags
             )
 

--- a/src/dou_dag_generator.py
+++ b/src/dou_dag_generator.py
@@ -248,7 +248,7 @@ class DouDigestDagGenerator():
                     email_to_list, attach_csv):
         """Builds the email content, the CSV if applies, and send it
         """
-        full_subject = f"{subject} - DOU de {report_date}"
+        full_subject = f"{subject} - DOs de {report_date}"
 
         search_report = ast.literal_eval(search_report)
         content = self.generate_email_content(search_report)

--- a/src/dou_dag_generator.py
+++ b/src/dou_dag_generator.py
@@ -131,7 +131,7 @@ class DouDigestDagGenerator():
 
             exec_dou_search_task = PythonOperator(
                 task_id='exec_dou_search',
-                python_callable=self.perform_searchs,
+                python_callable=self.perform_searches,
                 op_kwargs={
                     'sources': sources,
                     'territory_id': territory_id,

--- a/src/dou_dag_generator.py
+++ b/src/dou_dag_generator.py
@@ -47,7 +47,7 @@ class DouDigestDagGenerator():
     YAMLS_DIR = os.path.join(SOURCE_DIR, 'dag_confs/')
 
     parser = YAMLParser
-    searchers = Dict[str, BaseSearcher]
+    searchers: Dict[str, BaseSearcher]
 
     def __init__(self, on_retry_callback=None, on_failure_callback=None):
         self.searchers = {

--- a/src/parsers.py
+++ b/src/parsers.py
@@ -76,7 +76,7 @@ class YAMLParser(FileParser):
         field = search.get('field', 'TUDO')
         is_exact_search = search.get('is_exact_search', True)
         ignore_signature_match = search.get('ignore_signature_match', False)
-        force_rematch = search.get('force_rematch', False)
+        force_rematch = search.get('force_rematch', None)
         schedule = self._get_safe_schedule(dag, self.DEFAULT_SCHEDULE)
         dag_tags = dag.get('tags', [])
         # add default tags

--- a/src/parsers.py
+++ b/src/parsers.py
@@ -71,6 +71,7 @@ class YAMLParser(FileParser):
         terms, sql, conn_id = self._get_terms_params(search)
 
         # Optional fields
+        sources = search.get('sources', ['DOU'])
         dou_sections = search.get('dou_sections', ['TODOS'])
         search_date = search.get('date', 'DIA')
         field = search.get('field', 'TUDO')
@@ -87,6 +88,7 @@ class YAMLParser(FileParser):
 
         return (
             dag_id,
+            sources,
             dou_sections,
             search_date,
             field,

--- a/src/parsers.py
+++ b/src/parsers.py
@@ -72,6 +72,7 @@ class YAMLParser(FileParser):
 
         # Optional fields
         sources = search.get('sources', ['DOU'])
+        territory_id = search.get('territory_id', None)
         dou_sections = search.get('dou_sections', ['TODOS'])
         search_date = search.get('date', 'DIA')
         field = search.get('field', 'TUDO')
@@ -89,6 +90,7 @@ class YAMLParser(FileParser):
         return (
             dag_id,
             sources,
+            territory_id,
             dou_sections,
             search_date,
             field,

--- a/src/report_style.css
+++ b/src/report_style.css
@@ -28,7 +28,7 @@ h3 {
     font-size: 18px;
     font-weight: 500;
     line-height: 22px;
-    max-height: 44px;
+    /* max-height: 44px; */
     margin-bottom: 0;
     margin-top: 0;
     overflow: hidden;

--- a/src/searchers.py
+++ b/src/searchers.py
@@ -21,15 +21,15 @@ class DOUSearcher():
     SPLIT_MATCH_RE = re.compile(r'(.*?)<.*?>(.*?)<.*?>')
     dou_hook = DOUHook()
 
-    def exec_dou_search(self,
-                        term_list,
-                        dou_sections: [str],
-                        search_date,
-                        field,
-                        is_exact_search: bool,
-                        ignore_signature_match: bool,
-                        force_rematch: bool,
-                        **context):
+    def exec_search(self,
+                    term_list,
+                    dou_sections: [str],
+                    search_date,
+                    field,
+                    is_exact_search: bool,
+                    ignore_signature_match: bool,
+                    force_rematch: bool,
+                    **context):
         search_results = self._search_all_terms(
             self._cast_term_list(term_list),
             dou_sections,

--- a/src/searchers.py
+++ b/src/searchers.py
@@ -302,7 +302,7 @@ class QDSearcher(BaseSearcher):
     def parse_result(self, result: dict) -> dict:
         parsed = {}
         parsed['section'] = ("QD - Edição "
-            f"{'extraordinária' if result['is_extra_edition'] else 'ordinária'} ")
+            f"{'ordinária' if result.get('is_extra_edition') and not result['is_extra_edition'] else 'extraordinária'} ")
         parsed['title'] = ("Município de "
             f"{result['territory_name']} - {result['state_code']}")
         parsed['href'] = result['url']

--- a/src/searchers.py
+++ b/src/searchers.py
@@ -136,6 +136,7 @@ class DOUSearcher(BaseSearcher):
                           force_rematch) -> dict:
         search_results = {}
         for search_term in term_list:
+            logging.info('Starting search for term: %s', search_term)
             results = self._search_text_with_retry(
                 search_term=search_term,
                 sections=[Section[s] for s in dou_sections],

--- a/src/searchers.py
+++ b/src/searchers.py
@@ -286,16 +286,16 @@ class QDSearcher(BaseSearcher):
 
         req_result = requests.get(req_url, params=payload)
         search_results = json.loads(req_result.content)['gazettes']
-        all_results = []
+        parsed_results = []
         if search_results:
             for result in search_results:
-                all_results.append(self.parse_result(result))
+                parsed_results.append(self.parse_result(result))
 
         if force_rematch:
-            all_results = [r for r in all_results
+            clean_results = [r for r in parsed_results
                 if self._really_matched(search_term, r.get('abstract'))]
 
-        return all_results
+        return clean_results
 
 
     def parse_result(self, result: dict) -> dict:

--- a/src/searchers.py
+++ b/src/searchers.py
@@ -23,7 +23,7 @@ class BaseSearcher(ABC):
     CLEAN_HTML_RE = re.compile('<.*?>')
 
 
-    def _cast_term_list(self, pre_term_list: [list, str]) -> list:
+    def _cast_term_list(self, pre_term_list: Dict[list, str]) -> list:
         """If `pre_term_list` is a str (in the case it came from xcom)
         then its necessary to convert it back to dataframe and return
         the first column. Otherwise the `pre_term_list` is returned.
@@ -34,7 +34,7 @@ class BaseSearcher(ABC):
 
     def _group_results(self,
                        search_results: dict,
-                       term_list: [list, str]) -> dict:
+                       term_list: Dict[list, str]) -> dict:
         """Produces a grouped result based on if `term_list` is already
         the list of terms or it is a string received through xcom
         from `select_terms_from_db` task and the sql_query returned a
@@ -106,7 +106,7 @@ class DOUSearcher(BaseSearcher):
 
     def exec_search(self,
                     term_list,
-                    dou_sections: [str],
+                    dou_sections: List[str],
                     search_date,
                     field,
                     is_exact_search: bool,
@@ -222,7 +222,7 @@ class DOUSearcher(BaseSearcher):
                 norm_abstract_withou_start_name.startswith(norm_term))
         )
 
-    def _get_prior_and_matched_name(self, raw_html: str) -> (str, str):
+    def _get_prior_and_matched_name(self, raw_html: str) -> Tuple[str, str]:
         groups = self.SPLIT_MATCH_RE.match(raw_html).groups()
         return groups[0], groups[1]
 
@@ -240,7 +240,7 @@ class QDSearcher(BaseSearcher):
     def exec_search(self,
                     territory_id,
                     term_list,
-                    dou_sections: [str],
+                    dou_sections: List[str],
                     search_date,
                     field,
                     is_exact_search: bool,

--- a/src/searchers.py
+++ b/src/searchers.py
@@ -249,7 +249,7 @@ class QDSearcher(BaseSearcher):
                     reference_date: datetime):
         force_rematch = True if force_rematch is None else force_rematch
         term_list = self._cast_term_list(term_list)
-        tailored_date = reference_date - timedelta(days=2)
+        tailored_date = reference_date - timedelta(days=1)
         search_results = {}
         for search_term in term_list:
             results = self._search_term(

--- a/src/searchers.py
+++ b/src/searchers.py
@@ -284,10 +284,10 @@ class QDSearcher(BaseSearcher):
             ('published_until', reference_date.strftime('%Y-%m-%d')),
             ('querystring', f'"{search_term}"')]
 
-        req_url = (self.API_BASE_URL if not territory_id
-                   else urljoin(self.API_BASE_URL, str(territory_id)))
+        if territory_id:
+            payload.append(('territory_ids', territory_id))
 
-        req_result = requests.get(req_url, params=payload)
+        req_result = requests.get(self.API_BASE_URL, params=payload)
 
         parsed_results = [
             self.parse_result(result)

--- a/src/searchers.py
+++ b/src/searchers.py
@@ -282,23 +282,18 @@ class QDSearcher(BaseSearcher):
             ('number_of_excerpts', 3),
             ('published_since', reference_date.strftime('%Y-%m-%d')),
             ('published_until', reference_date.strftime('%Y-%m-%d')),
-            ('querystring', search_term)]
+            ('querystring', f'"{search_term}"')]
 
         req_url = (self.API_BASE_URL if not territory_id
                    else urljoin(self.API_BASE_URL, str(territory_id)))
 
         req_result = requests.get(req_url, params=payload)
-        search_results = json.loads(req_result.content)['gazettes']
-        parsed_results = []
-        if search_results:
-            for result in search_results:
-                parsed_results.append(self.parse_result(result))
 
-        if force_rematch:
-            clean_results = [r for r in parsed_results
-                if self._really_matched(search_term, r.get('abstract'))]
+        parsed_results = [
+            self.parse_result(result)
+            for result in json.loads(req_result.content)['gazettes']]
 
-        return clean_results
+        return parsed_results
 
 
     def parse_result(self, result: dict) -> dict:

--- a/src/searchers.py
+++ b/src/searchers.py
@@ -237,7 +237,7 @@ class DOUSearcher(BaseSearcher):
 
 class QDSearcher(BaseSearcher):
 
-    API_BASE_URL = 'https://queridodiario.ok.org.br/api/gazettes/'
+    API_BASE_URL = 'https://queridodiario.ok.org.br/api/gazettes'
     def exec_search(self,
                     territory_id,
                     term_list,
@@ -279,10 +279,11 @@ class QDSearcher(BaseSearcher):
             ('pre_tags', ('<span style="font-family: \'rawline\','
                           'sans-serif; background: #FFA;">')),
             ('post_tags', '</span>'),
-            ('number_of_fragments', 3),
-            ('since', reference_date.strftime('%Y-%m-%d')),
-            ('until', reference_date.strftime('%Y-%m-%d')),
-            ('keywords', search_term)]
+            ('number_of_excerpts', 3),
+            ('published_since', reference_date.strftime('%Y-%m-%d')),
+            ('published_until', reference_date.strftime('%Y-%m-%d')),
+            ('querystring', search_term)]
+
         req_url = (self.API_BASE_URL if not territory_id
                    else urljoin(self.API_BASE_URL, str(territory_id)))
 
@@ -309,7 +310,7 @@ class QDSearcher(BaseSearcher):
         parsed['href'] = result['url']
         parsed['abstract'] = (
             '<p>'
-            + '</p><p>'.join(result['highlight_texts']).replace('\n', '')
+            + '</p><p>'.join(result['excerpts']).replace('\n', '')
             + '</p>')
         parsed['date'] = result['date']
 

--- a/src/searchers.py
+++ b/src/searchers.py
@@ -2,20 +2,20 @@
 """
 
 import ast
+import json
+import logging
+import re
+import time
+from abc import ABC
+from datetime import datetime, timedelta
+from random import random
+from typing import Dict, List, Tuple
 from urllib.parse import urljoin
 
-from datetime import datetime, timedelta
-from abc import ABC
-import logging
-import time
-import re
-from random import random
-import json
 import pandas as pd
 import requests
+from FastETL.hooks.dou_hook import DOUHook, Field, SearchDate, Section
 from unidecode import unidecode
-
-from FastETL.hooks.dou_hook import DOUHook, Section, SearchDate, Field
 
 
 class BaseSearcher(ABC):

--- a/src/searchers.py
+++ b/src/searchers.py
@@ -4,7 +4,7 @@
 import ast
 from urllib.parse import urljoin
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from abc import ABC
 import logging
 import time
@@ -249,12 +249,13 @@ class QDSearcher(BaseSearcher):
                     reference_date: datetime):
         force_rematch = True if force_rematch is None else force_rematch
         term_list = self._cast_term_list(term_list)
+        tailored_date = reference_date - timedelta(days=2)
         search_results = {}
         for search_term in term_list:
             results = self._search_term(
                 territory_id=territory_id,
                 search_term=search_term,
-                reference_date=reference_date,
+                reference_date=tailored_date,
                 force_rematch=force_rematch,
                 )
             if results:

--- a/src/searchers.py
+++ b/src/searchers.py
@@ -302,7 +302,7 @@ class QDSearcher(BaseSearcher):
     def parse_result(self, result: dict) -> dict:
         parsed = {}
         parsed['section'] = ("QD - Edição "
-            f"{'ordinária' if result.get('is_extra_edition') and not result['is_extra_edition'] else 'extraordinária'} ")
+            f"{'extraordinária' if result.get('is_extra_edition') and result['is_extra_edition'] else 'ordinária'} ")
         parsed['title'] = ("Município de "
             f"{result['territory_name']} - {result['state_code']}")
         parsed['href'] = result['url']

--- a/src/searchers.py
+++ b/src/searchers.py
@@ -297,16 +297,16 @@ class QDSearcher(BaseSearcher):
 
 
     def parse_result(self, result: dict) -> dict:
-        parsed = {}
-        parsed['section'] = ("QD - Edição "
-            f"{'extraordinária' if result.get('is_extra_edition') and result['is_extra_edition'] else 'ordinária'} ")
-        parsed['title'] = ("Município de "
-            f"{result['territory_name']} - {result['state_code']}")
-        parsed['href'] = result['url']
-        parsed['abstract'] = (
-            '<p>'
-            + '</p><p>'.join(result['excerpts']).replace('\n', '')
-            + '</p>')
-        parsed['date'] = result['date']
-
-        return parsed
+        section = ('extraordinária'
+            if result.get('is_extra_edition', False) else 'ordinária')
+        return {
+            'section': f"QD - Edição {section} ",
+            'title': ("Município de "
+                f"{result['territory_name']} - {result['state_code']}"),
+            'href': result['url'],
+            'abstract': (
+                '<p>'
+                + '</p><p>'.join(result['excerpts']).replace('\n', '')
+                + '</p>'),
+            'date': result['date'],
+        }

--- a/src/searchers.py
+++ b/src/searchers.py
@@ -2,6 +2,7 @@
 """
 
 import ast
+from urllib.parse import urljoin
 
 from datetime import datetime
 from abc import ABC
@@ -237,6 +238,7 @@ class QDSearcher(BaseSearcher):
 
     API_BASE_URL = 'https://queridodiario.ok.org.br/api/gazettes/'
     def exec_search(self,
+                    territory_id,
                     term_list,
                     dou_sections: [str],
                     search_date,
@@ -250,6 +252,7 @@ class QDSearcher(BaseSearcher):
         search_results = {}
         for search_term in term_list:
             results = self._search_term(
+                territory_id=territory_id,
                 search_term=search_term,
                 reference_date=reference_date,
                 force_rematch=force_rematch,
@@ -262,6 +265,7 @@ class QDSearcher(BaseSearcher):
 
 
     def _search_term(self,
+                     territory_id,
                      search_term,
                      reference_date,
                      force_rematch: bool,
@@ -277,8 +281,10 @@ class QDSearcher(BaseSearcher):
             ('since', reference_date.strftime('%Y-%m-%d')),
             ('until', reference_date.strftime('%Y-%m-%d')),
             ('keywords', search_term)]
+        req_url = (self.API_BASE_URL if not territory_id
+                   else urljoin(self.API_BASE_URL, str(territory_id)))
 
-        req_result = requests.get(self.API_BASE_URL, params=payload)
+        req_result = requests.get(req_url, params=payload)
         search_results = json.loads(req_result.content)['gazettes']
         all_results = []
         if search_results:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,11 +4,13 @@
 import os
 
 import pytest
+from typing import Tuple
 
 from airflow import models
 from airflow.utils import db
 
-from dags.ro_dou.dou_dag_generator import DouDigestDagGenerator
+from dags.ro_dou.dou_dag_generator import (DouDigestDagGenerator,
+                                           SearchResult)
 from dags.ro_dou.parsers import YAMLParser
 from dags.ro_dou.searchers import DOUSearcher
 
@@ -359,3 +361,48 @@ def term_n_group():
             "1":"ATI"
         }
     }"""
+
+
+@pytest.fixture()
+def merge_results_samples() -> Tuple[SearchResult, SearchResult, SearchResult]:
+    results_dou = {
+        'grupo_1': {
+            'term_1': ['result1', 'result2', 'resultn'],
+            'term_2': ['result1', 'result2', 'resultn'],
+            'term_3': ['result1', 'result2', 'resultn'],
+        },
+        'grupo_2': {
+            'term_4': ['result1', 'result2', 'resultn'],
+            'term_5': ['result1', 'result2', 'resultn'],
+            'term_6': ['result1', 'result2', 'resultn'],
+        }
+    }
+    results_qd = {
+        'grupo_1': {
+            'term_2': ['result1', 'result2', 'resultn'],
+            'term_3': ['result1', 'result2', 'resultn'],
+            'term_10': ['result1', 'result2', 'resultn'],
+        },
+        'grupo_3': {
+            'term_7': ['result1', 'result2', 'resultn'],
+            'term_8': ['result1', 'result2', 'resultn'],
+            'term_9': ['result1', 'result2', 'resultn'],
+        }
+    }
+    merged_results = {
+        'grupo_2': {
+            'term_4': ['result1', 'result2', 'resultn'],
+            'term_5': ['result1', 'result2', 'resultn'],
+            'term_6': ['result1', 'result2', 'resultn']},
+        'grupo_3': {
+            'term_7': ['result1', 'result2', 'resultn'],
+            'term_8': ['result1', 'result2', 'resultn'],
+            'term_9': ['result1', 'result2', 'resultn']},
+        'grupo_1': {
+            'term_1': ['result1', 'result2', 'resultn'],
+            'term_2': ['result1', 'result2', 'resultn', 'result1', 'result2', 'resultn'],
+            'term_3': ['result1', 'result2', 'resultn', 'result1', 'result2', 'resultn'],
+            'term_10': ['result1', 'result2', 'resultn']}
+    }
+
+    return (results_dou, results_qd, merged_results)

--- a/tests/dag_generator_test.py
+++ b/tests/dag_generator_test.py
@@ -2,6 +2,8 @@
 """
 
 import pandas as pd
+from dags.ro_dou.dou_dag_generator import merge_results
+
 
 def test_repack_match(dag_gen, report_example):
     match_dict = report_example['single_group']['antonio de oliveira'][0]
@@ -60,3 +62,10 @@ def test_get_csv_tempfile__valid_file_name_suffix(dag_gen, report_example):
 def test_get_csv_tempfile__valid_csv(dag_gen, report_example):
     with dag_gen.get_csv_tempfile(report_example) as csv_file:
         assert pd.read_csv(csv_file.name) is not None
+
+def test_merge_results(merge_results_samples):
+    merged_result = merge_results(
+        merge_results_samples[0],
+        merge_results_samples[1],
+    )
+    assert merged_result == merge_results_samples[2]

--- a/tests/parsers_test.py
+++ b/tests/parsers_test.py
@@ -34,6 +34,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
          (
              'basic_example',
              ['DOU'],
+             None,
              ['TODOS'],
              'DIA',
              'TUDO',
@@ -57,6 +58,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
          (
              'all_parameters_example',
              ['DOU'],
+             None,
              ['SECAO_1', 'EDICAO_SUPLEMENTAR'],
              'MES',
              'TUDO',
@@ -81,6 +83,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
          (
              'terms_from_db_example',
              ['DOU'],
+             None,
              ['TODOS'],
              'MES',
              'TUDO',
@@ -105,6 +108,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
         ),
     ])
 def test_parse(filepath, result_tuple):
-    filepath = os.path.join(DouDigestDagGenerator().YAMLS_DIR,
-                            filepath)
-    assert YAMLParser(filepath=filepath).parse() == result_tuple
+    filepath = os.path.join(DouDigestDagGenerator().YAMLS_DIR, filepath)
+    parsed = YAMLParser(filepath=filepath).parse()
+
+    assert parsed == result_tuple

--- a/tests/parsers_test.py
+++ b/tests/parsers_test.py
@@ -33,12 +33,13 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
         ('basic_example.yaml',
          (
              'basic_example',
+             ['DOU'],
              ['TODOS'],
              'DIA',
              'TUDO',
              True,
              False,
-             False,
+             None,
              ['dados abertos',
              'governo aberto',
              'lei de acesso à informação'],
@@ -55,6 +56,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
         ('all_parameters_example.yaml',
          (
              'all_parameters_example',
+             ['DOU'],
              ['SECAO_1', 'EDICAO_SUPLEMENTAR'],
              'MES',
              'TUDO',
@@ -78,12 +80,13 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
         ('terms_from_db_example.yaml',
          (
              'terms_from_db_example',
+             ['DOU'],
              ['TODOS'],
              'MES',
              'TUDO',
              True,
              False,
-             False,
+             None,
              [],
              ("SELECT 'cloroquina' as TERMO, 'Ações inefetivas' as GRUPO "
               "UNION SELECT 'ivermectina' as TERMO, 'Ações inefetivas' as GRUPO "


### PR DESCRIPTION
O Querido Diário é uma plataforma de coleta e indexação dos conteúdos dos Diários Oficiais de vários municípios brasileiros. Com estas mudanças é possível configurar dags para pesquisar também nos conteúdos indexados pelo Querido Diário e no DOU concomitantemente.

Além das mudanças no código fonte também foram adicionadas instruções ao README.