### PR TITLE
Adiciona tentativas de execução na função search_text_with_retry

### DIFF
--- a/src/searchers.py
+++ b/src/searchers.py
@@ -171,27 +171,29 @@ class DOUSearcher(BaseSearcher):
         search_date,
         field,
         is_exact_search,
+        max_retries=5
     ) -> list:
-        try:
-            return self.dou_hook.search_text(
-                search_term=search_term,
-                sections=sections,
-                reference_date=reference_date,
-                search_date=search_date,
-                field=field,
-                is_exact_search=is_exact_search,
-                )
-        except:
-            logging.info('Sleeping for 30 seconds before retry dou_hook.search_text().')
-            time.sleep(30)
-            return self.dou_hook.search_text(
-                search_term=search_term,
-                sections=sections,
-                reference_date=reference_date,
-                search_date=search_date,
-                field=field,
-                is_exact_search=is_exact_search,
-                )
+
+        retry=1
+
+        while True:
+            try:
+                return self.dou_hook.search_text(
+                    search_term=search_term,
+                    sections=sections,
+                    reference_date=reference_date,
+                    search_date=search_date,
+                    field=field,
+                    is_exact_search=is_exact_search,
+                    )
+            except:
+                if retry > max_retries:
+                    logging.error('Error - Max retries reached')
+                    raise Exception
+                logging.info('Attemp %s of %s: ', retry, max_retries)
+                logging.info('Sleeping for 30 seconds before retry dou_hook.search_text().')
+                time.sleep(30)
+                retry += 1
 
     def _is_signature(self, search_term: str, abstract: str) -> bool:
         """Verifica se o `search_term` (geralmente usado para busca por


### PR DESCRIPTION
Após as restrições de bots no portal da IN e necessidade de utilização da biblioteca _Selenium_ (#19), as DAGs do Ro-Dou que envolvem busca baseada em lista de servidores têm gerado erros de instabilidade no retorno do _json_ pelo _BeautifulSoap_ através da página de retorno da busca dos termos. 

`    search_results = json.loads(script_tag.contents[0])['jsonArray']
AttributeError: 'NoneType' object has no attribute 'contents'`

Como a função **search_text_with_retry** previa apenas uma tentativa de reexecução da função após um _Exception_, para contornar o problema e permitir a execução completa das DAGs, sugere-se aumentar o número de tentativas de execução da função.