### PR TITLE
Make tests run in colored output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,4 @@ down:
 
 .PHONY: tests
 tests:
-	docker exec airflow-webserver sh -c "cd /opt/airflow/tests/ && pytest -vvv"
+	docker exec airflow-webserver sh -c "cd /opt/airflow/tests/ && pytest -vvv --color=yes"


### PR DESCRIPTION
Tests with colored output make it easier to spot errors.