### PR TITLE
Altera id da basic_example_skip_null

### DIFF
--- a/dag_confs/basic_example_skip_null.yaml
+++ b/dag_confs/basic_example_skip_null.yaml
@@ -1,5 +1,5 @@
 dag:
-  id: basic_example
+  id: basic_example_send_null
   description: DAG de teste
   search:
     terms:


### PR DESCRIPTION
O id da DAG do arquivo basic_example_skip_null.yaml estava o mesmo da DAG do basic_example.yaml. 

A duplicidade de id gera conflito na execução da DAG no Airflow.