### PR TITLE
Implementa feature de documentação markdown e informações úteis

### DIFF
--- a/dag_confs/basic_example.yaml
+++ b/dag_confs/basic_example.yaml
@@ -10,4 +10,12 @@ dag:
     emails:
       - destination@economia.gov.br
     subject: "Teste do Ro-dou"
+  doc_md: >-
+    ## Ola!
 
+    Esta é uma DAG de teste. Esta descrição é opcional e pode ser definida no
+    parâmetro `doc_md`.
+
+      * Ah, aqui você também pode usar *markdown* para
+      * escrever listas, por exemplo,
+      * ou colocar [ĺinks](graph)!

--- a/dag_confs/basic_example_skip_null.yaml
+++ b/dag_confs/basic_example_skip_null.yaml
@@ -1,5 +1,5 @@
 dag:
-  id: basic_example
+  id: basic_example_skip_null
   description: DAG de teste
   search:
     terms:

--- a/src/parsers.py
+++ b/src/parsers.py
@@ -84,7 +84,7 @@ class YAMLParser(FileParser):
         # add default tags
         dag_tags.append('dou')
         dag_tags.append('generated_dag')
-        subject = report.get('subject', 'Extraçao do DOU')
+        subject = report.get('subject', 'Extração do DOU')
         skip_null = report.get('skip_null', True)
         attach_csv = report.get('attach_csv', False)
         

--- a/tests/parsers_test.py
+++ b/tests/parsers_test.py
@@ -4,6 +4,7 @@
 import os
 import sys
 import inspect
+import textwrap
 
 import pytest
 
@@ -13,7 +14,7 @@ currentdir = os.path.dirname(
     os.path.abspath(inspect.getfile(inspect.currentframe())))
 parentdir = os.path.dirname(currentdir)
 sys.path.insert(0, parentdir)
-from dou_dag_generator import DouDigestDagGenerator, YAMLParser
+from dou_dag_generator import DouDigestDagGenerator, YAMLParser, DAGConfig
 
 @pytest.mark.parametrize(
     'dag_id, size, hashed',
@@ -28,113 +29,122 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
     assert yaml_parser._hash_dag_id(dag_id, size) == hashed
 
 @pytest.mark.parametrize(
-    'filepath, result_tuple',
+    "filepath, result_tuple",
     [
-        ('basic_example.yaml',
-         (
-             'basic_example',
-             ['DOU'],
-             None,
-             ['TODOS'],
-             'DIA',
-             'TUDO',
-             True,
-             False,
-             None,
-             ['dados abertos',
-             'governo aberto',
-             'lei de acesso à informação'],
-             None,
-             None,
-             ['destination@economia.gov.br'],
-             'Teste do Ro-dou',
-             False,
-             '37 5 * * *',
-             'DAG de teste',
-             True,
-             {'dou', 'generated_dag'}
-             )
+        ("basic_example.yaml",
+            {
+                "dag_id": "basic_example",
+                "sources": ["DOU"],
+                "territory_id": None,
+                "dou_sections": ["TODOS"],
+                "search_date": "DIA",
+                "field": "TUDO",
+                "is_exact_search": True,
+                "ignore_signature_match": False,
+                "force_rematch": None,
+                "terms": ["dados abertos",
+                    "governo aberto",
+                    "lei de acesso à informação"],
+                "sql": None,
+                "conn_id": None,
+                "emails": ["destination@economia.gov.br"],
+                "subject": "Teste do Ro-dou",
+                "attach_csv": False,
+                "schedule": "37 5 * * *",
+                "description": "DAG de teste",
+                "skip_null": True,
+                "doc_md": textwrap.dedent("""
+                    ## Ola!
+                    Esta é uma DAG de teste. Esta descrição é opcional e pode ser definida no parâmetro `doc_md`.
+
+                      * Ah, aqui você também pode usar *markdown* para
+                      * escrever listas, por exemplo,
+                      * ou colocar [ĺinks](graph)!""").strip(),
+                "dag_tags": {"dou", "generated_dag"}
+            }
         ),
-        ('all_parameters_example.yaml',
-         (
-             'all_parameters_example',
-             ['DOU'],
-             None,
-             ['SECAO_1', 'EDICAO_SUPLEMENTAR'],
-             'MES',
-             'TUDO',
-             True,
-             True,
-             True,
-             ['dados abertos',
-             'governo aberto',
-             'lei de acesso à informação',
-             ],
-             None,
-             None,
-             ['dest1@economia.gov.br', 'dest2@economia.gov.br'],
-             'Assunto do Email',
-             True,
-             '0 8 * * MON-FRI',
-             'DAG exemplo utilizando todos os demais parâmetros.',
-             True,
-             {'dou', 'generated_dag', 'projeto_a', 'departamento_x'}
-             )
+        ("all_parameters_example.yaml",
+            {
+                "dag_id": "all_parameters_example",
+                "sources": ["DOU"],
+                "territory_id": None,
+                "dou_sections": ["SECAO_1", "EDICAO_SUPLEMENTAR"],
+                "search_date": "MES",
+                "field": "TUDO",
+                "is_exact_search": True,
+                "ignore_signature_match": True,
+                "force_rematch": True,
+                "terms": ["dados abertos",
+                    "governo aberto",
+                    "lei de acesso à informação"],
+                "sql": None,
+                "conn_id": None,
+                "emails": ["dest1@economia.gov.br", "dest2@economia.gov.br"],
+                "subject": "Assunto do Email",
+                "attach_csv": True,
+                "schedule": "0 8 * * MON-FRI",
+                "description": "DAG exemplo utilizando todos os demais parâmetros.",
+                "skip_null": True,
+                "doc_md": None,
+                "dag_tags": {"dou", "generated_dag", "projeto_a", "departamento_x"}
+            }
         ),
-        ('terms_from_db_example.yaml',
-         (
-             'terms_from_db_example',
-             ['DOU'],
-             None,
-             ['TODOS'],
-             'MES',
-             'TUDO',
-             True,
-             False,
-             None,
-             [],
-             ("SELECT 'cloroquina' as TERMO, 'Ações inefetivas' as GRUPO "
-              "UNION SELECT 'ivermectina' as TERMO, 'Ações inefetivas' as GRUPO "
-              "UNION SELECT 'vacina contra covid' as TERMO, 'Ações efetivas' as GRUPO "
-              "UNION SELECT 'higienização das mãos' as TERMO, 'Ações efetivas' as GRUPO "
-              "UNION SELECT 'uso de máscara' as TERMO, 'Ações efetivas' as GRUPO "
-              "UNION SELECT 'distanciamento social' as TERMO, 'Ações efetivas' as GRUPO\n"),
-             'example_database_conn',
-             ['destination@economia.gov.br'],
-             '[String] com caracteres especiais deve estar entre aspas',
-             True,
-             '2 5 * * *',
-             'DAG de teste',
-             True,
-             {'dou', 'generated_dag'}
-             )
+        ("terms_from_db_example.yaml",
+            {
+                "dag_id": "terms_from_db_example",
+                "sources": ["DOU"],
+                "territory_id": None,
+                "dou_sections": ["TODOS"],
+                "search_date": "MES",
+                "field": "TUDO",
+                "is_exact_search": True,
+                "ignore_signature_match": False,
+                "force_rematch": None,
+                "terms": [],
+                "sql": ("SELECT 'cloroquina' as TERMO, 'Ações inefetivas' as GRUPO "
+                    "UNION SELECT 'ivermectina' as TERMO, 'Ações inefetivas' as GRUPO "
+                    "UNION SELECT 'vacina contra covid' as TERMO, 'Ações efetivas' as GRUPO "
+                    "UNION SELECT 'higienização das mãos' as TERMO, 'Ações efetivas' as GRUPO "
+                    "UNION SELECT 'uso de máscara' as TERMO, 'Ações efetivas' as GRUPO "
+                    "UNION SELECT 'distanciamento social' as TERMO, 'Ações efetivas' as GRUPO\n"),
+                "conn_id": "example_database_conn",
+                "emails": ["destination@economia.gov.br"],
+                "subject": "[String] com caracteres especiais deve estar entre aspas",
+                "attach_csv": True,
+                "schedule": "2 5 * * *",
+                "description": "DAG de teste",
+                "skip_null": True,
+                "doc_md": None,
+                "dag_tags": {"dou", "generated_dag"}
+            }
         ),
-        ('basic_example_skip_null.yaml',
-         (
-             'basic_example_skip_null',
-             ['DOU'],
-             None,
-             ['TODOS'],
-             'DIA',
-             'TUDO',
-             True,
-             False,
-             None,
-             ['cimentodaaroeira'],
-             None,
-             None,
-             ['destination@economia.gov.br'],
-             'Teste do Ro-dou',
-             False,
-             '37 5 * * *',
-             'DAG de teste',
-             False,
-             {'dou', 'generated_dag'}
-             )
+        ("basic_example_skip_null.yaml",
+            {
+                "dag_id": "basic_example_skip_null",
+                "sources": ["DOU"],
+                "territory_id": None,
+                "dou_sections": ["TODOS"],
+                "search_date": "DIA",
+                "field": "TUDO",
+                "is_exact_search": True,
+                "ignore_signature_match": False,
+                "force_rematch": None,
+                "terms": ["cimentodaaroeira"],
+                "sql": None,
+                "conn_id": None,
+                "emails": ["destination@economia.gov.br"],
+                "subject": 'Teste do Ro-dou',
+                "attach_csv": False,
+                "schedule": "29 5 * * *",
+                "description": "DAG de teste",
+                "skip_null": False,
+                "doc_md": None,
+                "dag_tags": {"dou", "generated_dag"}
+            },
         ),
     ])
 def test_parse(filepath, result_tuple):
     filepath = os.path.join(DouDigestDagGenerator().YAMLS_DIR, filepath)
     parsed = YAMLParser(filepath=filepath).parse()
 
-    assert parsed == result_tuple
+    assert parsed == DAGConfig(**result_tuple)

--- a/tests/parsers_test.py
+++ b/tests/parsers_test.py
@@ -111,7 +111,7 @@ def test_hash_dag_id(yaml_parser, dag_id, size, hashed):
         ),
         ('basic_example_skip_null.yaml',
          (
-             'basic_example',
+             'basic_example_skip_null',
              ['DOU'],
              None,
              ['TODOS'],


### PR DESCRIPTION
Este PR acrescenta a feature para se usar o parâmetro `doc_md` no arquivo de configuração yaml. O conteúdo aceita formatação em *markdown*, que será exibida na opção "DAG Docs"  do Airflow.

Além disso, lá também será informado o nome do arquivo yaml que foi usado para criar a DAG e os parâmetros usados para criá-la, facilitando a sua manutenção.

Inclui também uma correção no id da DAG de exemplo criada para ilustrar o parâmetro `skip_null`, que havia sido criada no PR #24.

Fixes #27 #30