### PR TITLE
[dou_dag_generator] enables to find ro_dou folder inside airflow dags…

### DIFF
--- a/src/dou_dag_generator.py
+++ b/src/dou_dag_generator.py
@@ -43,8 +43,20 @@ class DouDigestDagGenerator():
     database.
     """
 
-    SOURCE_DIR = os.path.join(os.environ['AIRFLOW_HOME'], 'dags/ro_dou/')
-    YAMLS_DIR = os.path.join(SOURCE_DIR, 'dag_confs/')
+    base_dir = os.path.join(os.environ['AIRFLOW_HOME'], 'dags')
+    dir_name = 'ro_dou'
+
+    # Walk through the directory tree to find the directory
+    for root, dirs, files in os.walk(base_dir):
+        if dir_name in dirs:
+            # If the directory is found, print its path and exit the loop
+            SOURCE_DIR = os.path.join(root, dir_name)
+            break
+    else:
+        # If the directory is not found, print a message
+        raise Exception("{dir_name} directory not found in {base_dir} or its subdirectories.")
+
+    YAMLS_DIR = os.path.join(SOURCE_DIR, 'dag_confs')
 
     parser = YAMLParser
     searchers: Dict[str, BaseSearcher]
@@ -283,7 +295,7 @@ class DouDigestDagGenerator():
                     email_to_list, attach_csv, skip_null):
         """Builds the email content, the CSV if applies, and send it
         """
-        full_subject = f"{subject} - DOs de {report_date}" 
+        full_subject = f"{subject} - DOs de {report_date}"
         search_report = ast.literal_eval(search_report_str)
         items = ['contains' for k, v in search_report.items() if v]
         if items:


### PR DESCRIPTION
… dir

Previous code expect ro_dou folder on $AIRFLOW_HOME/dags/ro_dou, now it find where it is at $AIRFLOW_HOME/dags.

Could be:
$AIRFLOW_HOME/dags/ro_dou or $AIRFLOW_HOME/dags/<organization_name>/ro_dou or any other location inside $AIRFLOW_HOME/dags