### PR TITLE
Decouple this project from the airflow2-docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM apache/airflow:2.5.1
+
+RUN pip install --no-cache-dir --user 'apache-airflow[microsoft.mssql,google_auth]'
+COPY requirements.txt /
+RUN pip install --no-cache-dir -r /requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,8 @@
     version: '3'
     x-airflow-common:
       &airflow-common
-      image: ghcr.io/economiagovbr/airflow2-docker:latest
+      build:
+        context: .
       environment:
         &airflow-common-env
         AIRFLOW__CORE__EXECUTOR: LocalExecutor

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+s3fs==2023.1.0
+ipdb==0.13.11
+pytest==7.2.1
+mock==5.0.1
+pytest-mock==3.10.0
+unidecode==1.2.0
+xlrd==1.2.0
+ijson==3.0.4
+openpyxl==3.0.7


### PR DESCRIPTION
So far this project has relied on a docker image used by the ministry dev team, this has limiting the environment customization needed by some ongoing evolutions.

This PR creates an exclusive container to be used by Ro-dou.

Fixes #48