### PR TITLE
Bundle src code and plugin into docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,33 @@
 FROM apache/airflow:2.5.1
 
+USER root
+
+# Copy Ro-dou core files from the host Docker context
+COPY src /opt/airflow/dags/ro_dou
+
+# Install Git
+RUN apt-get update && \
+    apt-get install -y git && \
+    rm -rf /var/lib/apt/lists/*
+
+# Clone the FastETL GitHub repository and copy specified files
+RUN git clone https://github.com/economiagovbr/FastETL.git /tmp/repo-FastETL && \
+    mkdir -p /opt/airflow/plugins/FastETL/hooks && \
+    mkdir -p /opt/airflow/plugins/FastETL/custom_functions/utils && \
+    cp /tmp/repo-FastETL/hooks/dou_hook.py /opt/airflow/plugins/FastETL/hooks/dou_hook.py && \
+    cp -r /tmp/repo-FastETL/custom_functions/utils/* /opt/airflow/plugins/FastETL/custom_functions/utils/
+
+# Remove Git and clean up package cache
+RUN apt-get remove -y git && \
+    apt-get autoremove -y && \
+    rm -rf /tmp/repo-ro-dou && \
+    rm -rf /tmp/repo-FastETL
+
+USER airflow
+
+# Install additional Airflow dependencies
 RUN pip install --no-cache-dir --user 'apache-airflow[microsoft.mssql,google_auth]'
+
+# Copy and install requirements.txt
 COPY requirements.txt /
 RUN pip install --no-cache-dir -r /requirements.txt

--- a/README.md
+++ b/README.md
@@ -27,14 +27,9 @@ clonar o repositório no seu computador, acesse o diretório pela linha de
 comando e execute os comandos a seguir:
 
 ```bash
-make install-deps
-```
-Este comando baixa as dependências necessárias.
-
-```bash
 make run
 ```
-Este comando baixa as imagens docker e sobe todos os contêineres do Ro-dou.
+Este comando baixa as imagens docker necessárias, faz build da contêiner do Ro-dou e sobe tudo.
 
 O Airflow pode demorar alguns minutos para se configurar a primeira vez. Após
 isso ele estará disponível em http://localhost:8080/. Para se autenticar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,9 +74,6 @@
         - ./src:/opt/airflow/dags/ro_dou
         - ./dag_confs:/opt/airflow/dags/ro_dou/dag_confs
         - ./tests:/opt/airflow/tests
-
-        - ./FastETL/hooks/dou_hook.py:/opt/airflow/plugins/FastETL/hooks/dou_hook.py
-        - ./FastETL/custom_functions/utils/:/opt/airflow/plugins/FastETL/custom_functions/utils/
       depends_on:
         postgres:
           condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,9 +71,9 @@
 
         AIRFLOW_CONN_EXAMPLE_DATABASE_CONN: postgresql://airflow:airflow@postgres:5432/airflow
       volumes:
-        - ./src:/opt/airflow/dags/ro_dou
+        - ./src:/opt/airflow/dags/ro_dou # for development purpose
         - ./dag_confs:/opt/airflow/dags/ro_dou/dag_confs
-        - ./tests:/opt/airflow/tests
+        - ./tests:/opt/airflow/tests # for test purpose
       depends_on:
         postgres:
           condition: service_healthy


### PR DESCRIPTION
This changes the Dockerfile adding some steps to install the Ro-dou src code and FastETL plugin code in build time instead of mapping them as docker volumes.

It simplifies production deployment.

Fix #52 