### PR TITLE
Workflow to build and publish docker image

### DIFF
--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -31,11 +31,11 @@ jobs:
       with:
         context: .
         push: true
-        tags: ghcr.io/${{ github.repository }}:${{ env.TAG_NAME }}
+        tags: ghcr.io/${{ github.repository_owner }}/ro-dou:${{ env.TAG_NAME }}
 
     - name: Build and push Docker image with latest tag
       uses: docker/build-push-action@v2
       with:
         context: .
         push: true
-        tags: ghcr.io/${{ github.repository }}:latest
+        tags: ghcr.io/${{ github.repository_owner }}/ro-dou:latest

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -2,9 +2,8 @@ name: Build and Publish Docker Image
 
 on:
   push:
-    branches:
-      - main
-      - build_publish_image
+    tags:
+      - '*'
 
 jobs:
   build_and_push:
@@ -23,9 +22,20 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build and push Docker image
+    - name: Extract tag name
+      shell: bash
+      run: echo "TAG_NAME=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_ENV
+
+    - name: Build and push Docker image with tag
       uses: docker/build-push-action@v2
       with:
         context: .
         push: true
-        tags: ghcr.io/${{ github.repository_owner }}/ro-dou:latest
+        tags: ghcr.io/${{ github.repository }}:${{ env.TAG_NAME }}
+
+    - name: Build and push Docker image with latest tag
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -28,4 +28,4 @@ jobs:
       with:
         context: .
         push: true
-        tags: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:latest
+        tags: ghcr.io/${{ github.repository_owner }}/ro-dou:latest

--- a/.github/workflows/docker_build_and_publish.yml
+++ b/.github/workflows/docker_build_and_publish.yml
@@ -1,0 +1,31 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+      - build_publish_image
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:latest


### PR DESCRIPTION
**Description**

This Pull Request adds a new GitHub Actions workflow file that builds and publishes a Docker image to the GitHub Container Registry. The workflow is triggered by Git tag pushes.

**Changes Made**

- Added a new YAML file to the `.github/workflows/` directory that describes the workflow.
- The workflow consists of several steps that perform actions such as checking out the code, setting up Docker Buildx, logging in to the GitHub Container Registry, and building/pushing the Docker image.

**Reason for Changes**

The reason for creating this workflow is to automate the process of building and publishing Docker images to the GitHub Container Registry whenever a new Git tag is pushed. This will save time and effort for developers who need to build and distribute Docker images.

**Testing Done**

The workflow was tested locally and verified that the Docker image was built and pushed to the GitHub Container Registry successfully.
